### PR TITLE
Separate method to register for remote notifications (iOS)

### DIFF
--- a/cordova-plugin-fcm-with-dependecy-updated.podspec
+++ b/cordova-plugin-fcm-with-dependecy-updated.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "cordova-plugin-fcm-with-dependecy-updated"
-  spec.version      = "4.1.1"
+  spec.version      = "4.2.0"
   spec.summary      = "Google FCM Push Notifications Cordova Plugin"
 
   # This description is used to generate tags and improve search results.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.1.1",
+  "version": "4.2.0",
   "name": "cordova-plugin-fcm-with-dependecy-updated",
   "cordova_name": "Cordova FCM Push Plugin",
   "description": "Google Firebase Cloud Messaging Cordova Push Plugin fork with dependecy updated",

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-fcm-with-dependecy-updated" version="4.1.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-fcm-with-dependecy-updated" version="4.2.0">
 	<name>Cordova FCM Push Plugin</name>
 	<description>Google Firebase Cloud Messaging Cordova Push Plugin fork with dependecy updated</description>
 	<license>MIT</license>

--- a/src/FCMPlugin.d.ts
+++ b/src/FCMPlugin.d.ts
@@ -14,6 +14,8 @@ export interface INotificationData {
 }
 
 export interface FCMPlugin {
+  registerForRemoteNotifications(): void;
+
   hasPermission(
     onSuccess: (doesIt: boolean | null) => void,
     onError?: (error: Error) => void

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -50,37 +50,13 @@ NSString *const kGCMMessageIDKey = @"gcm.message_id";
     }
     // [END configure_firebase]
     
-    // iOS 9 or earlier Disable the deprecation warnings.
-    // [START register_for_notifications]
-    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_9_x_Max) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        UIUserNotificationType allNotificationTypes =
-        (UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);
-        UIUserNotificationSettings *settings =
-        [UIUserNotificationSettings settingsForTypes:allNotificationTypes categories:nil];
-        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-#pragma clang diagnostic pop
-    } else {
-        // iOS 10 or later
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-        UNAuthorizationOptions authOptions = UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
-        [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
-            if (granted) {
-                [[UIApplication sharedApplication] registerForRemoteNotifications];
-            } else {
-                NSLog(@"User Notification permission denied: %@", error.localizedDescription);
-            }
-        }];
-        
-        // For iOS 10 display notification (sent via APNS)
-        [UNUserNotificationCenter currentNotificationCenter].delegate = self;
-        // For iOS 10 data message (sent via FCM)
-        [FIRMessaging messaging].delegate = self;
+    // For iOS 10 display notification (sent via APNS)
+    [UNUserNotificationCenter currentNotificationCenter].delegate = self;
+    // For iOS 10 data message (sent via FCM)
+    [FIRMessaging messaging].delegate = self;
 #endif
-    }
-    // [END register_for_notifications]
+    
     return YES;
 }
 

--- a/src/ios/FCMPlugin.h
+++ b/src/ios/FCMPlugin.h
@@ -11,6 +11,7 @@
 + (void)setInitialFCMToken:(NSString*) token;
 - (void)notifyFCMTokenRefresh:(NSString*) token;
 - (void)ready:(CDVInvokedUrlCommand*)command;
+- (void)registerForRemoteNotifications:(CDVInvokedUrlCommand*)command;
 - (void)hasPermission:(CDVInvokedUrlCommand*)command;
 - (void)getToken:(CDVInvokedUrlCommand*)command;
 - (void)getAPNSToken:(CDVInvokedUrlCommand*)command;

--- a/www/FCMPlugin.js
+++ b/www/FCMPlugin.js
@@ -5,6 +5,14 @@ function FCMPlugin() {
   console.log("FCMPlugin.js: is created");
 }
 
+// REGISTER FOR REMOTE NOTIFICATIONS
+FCMPlugin.prototype.registerForRemoteNotifications = function() {
+  if (cordova.platformId !== "ios") {
+    return;
+  }
+  exec(null, null, "FCMPlugin", "registerForRemoteNotifications", []);
+};
+               
 // CHECK FOR PERMISSION
 FCMPlugin.prototype.hasPermission = function(success, error) {
   if (cordova.platformId !== "ios") {


### PR DESCRIPTION
Removed automatic registration for remote notifications from app launch method.
Added separate method to register for remote notifications.